### PR TITLE
Force work_restart to be 128-byte aligned.

### DIFF
--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -910,8 +910,8 @@ int main (int argc, char *argv[])
 		openlog("cpuminer", LOG_PID, LOG_USER);
 #endif
 
-	work_restart = calloc(opt_n_threads, sizeof(*work_restart));
-	if (!work_restart)
+	if (posix_memalign(&work_restart, 128,
+			   sizeof(*work_restart) * opt_n_threads))
 		return 1;
 
 	thr_info = calloc(opt_n_threads + 2, sizeof(*thr));


### PR DESCRIPTION
This fixes a bug on my system where mfc_get was failing on
work_restart_pointer because it was not 128-byte aligned.
